### PR TITLE
Fixes #70 & #71

### DIFF
--- a/themes/codeisscience/layouts/partials/header.html
+++ b/themes/codeisscience/layouts/partials/header.html
@@ -8,8 +8,10 @@
 	{{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 	{{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
 	<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css">
-	{{ if .RSSLink -}}<link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}">{{- end }}
-	{{ .Hugo.Generator }}
+    {{ with .OutputFormats.Get "rss" -}}
+        {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+    {{ end -}}
+    {{ hugo.Generator }}
 	<link href="https://fonts.googleapis.com/css?family=Encode+Sans+Expanded" rel="stylesheet">
 	<link rel="shortcut icon" href="{{ .Site.BaseURL }}images/favicon.png" type="image/png">
 	<link rel="icon" href="{{ .Site.BaseURL }}images/favicon.png" type="image/png">


### PR DESCRIPTION
Links to relevant issues/docs#

Fixes #70 and #71 

## What does this PR do?

Summary of changes:

* Fixes warning "Page.Hugo is deprecated" by using global "hugo" instead of ".Hugo"
* Fixes warning "Page.RSSLink is deprecated" by using OutputFormats instead of .RSS
